### PR TITLE
Release 0.2.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 test_task:
   matrix:
     - container:
-        image: rust:1.29
+        image: rust:1.36
     - container:
         image: rust:latest
     - allow_failures: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 test_task:
   matrix:
     - container:
-        image: rust:1.36
+        image: rust:1.38
     - container:
         image: rust:latest
     - allow_failures: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon-cond"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 description = "Experimental iterator wrapper that is conditionally parallel or serial."
 repository = "https://github.com/cuviper/rayon-cond"
@@ -11,6 +11,6 @@ categories = ["concurrency"]
 exclude = ["/.cirrus.yml"]
 
 [dependencies]
-rayon = "1.0.3"
-itertools = "0.8"
-either = "1.5.0"
+rayon = "1.5"
+itertools = "0.10"
+either = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["parallel", "iterator"]
 categories = ["concurrency"]
 exclude = ["/.cirrus.yml"]
+edition = "2018"
 
 [dependencies]
 rayon = "1.5"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crate](https://img.shields.io/crates/v/rayon-cond.svg)](https://crates.io/crates/rayon-cond)
 [![Documentation](https://docs.rs/rayon-cond/badge.svg)](https://docs.rs/rayon-cond)
-![minimum rustc 1.29](https://img.shields.io/badge/rustc-1.29+-red.svg)
+![minimum rustc 1.36](https://img.shields.io/badge/rustc-1.36+-red.svg)
 [![Build Status](https://api.cirrus-ci.com/github/cuviper/rayon-cond.svg)](https://cirrus-ci.com/github/cuviper/rayon-cond)
 
 Experimental iterator wrapper that is conditionally parallel or serial, using
@@ -14,7 +14,7 @@ First add this crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rayon-cond = "0.1"
+rayon-cond = "0.2"
 ```
 
 Then in your code, it may be used something like this:
@@ -36,7 +36,7 @@ fn main() {
 }
 ```
 
-`rayon-cond` currently requires `rustc 1.29.0` or greater.
+`rayon-cond` currently requires `rustc 1.36.0` or greater.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ rayon-cond = "0.2"
 Then in your code, it may be used something like this:
 
 ```rust
-extern crate rayon_cond;
-
 use rayon_cond::CondIterator;
 
 fn main() {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Crate](https://img.shields.io/crates/v/rayon-cond.svg)](https://crates.io/crates/rayon-cond)
 [![Documentation](https://docs.rs/rayon-cond/badge.svg)](https://docs.rs/rayon-cond)
-![minimum rustc 1.36](https://img.shields.io/badge/rustc-1.36+-red.svg)
+![minimum rustc 1.38](https://img.shields.io/badge/rustc-1.38+-red.svg)
 [![Build Status](https://api.cirrus-ci.com/github/cuviper/rayon-cond.svg)](https://cirrus-ci.com/github/cuviper/rayon-cond)
 
 Experimental iterator wrapper that is conditionally parallel or serial, using
@@ -34,7 +34,7 @@ fn main() {
 }
 ```
 
-`rayon-cond` currently requires `rustc 1.36.0` or greater.
+`rayon-cond` currently requires `rustc 1.38.0` or greater.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rayon-cond = "0.1"
+//! rayon-cond = "0.2"
 //! ```
 //!
 //! Then in your code, it may be used something like this:
@@ -516,7 +516,10 @@ where
     where
         P::Item: Clone,
     {
-        wrap_either!(self, iter => iter.intersperse(element))
+        match self {
+            Parallel(iter) => Parallel(iter.intersperse(element)),
+            Serial(iter) => Serial(Itertools::intersperse(iter, element)),
+        }
     }
 
     pub fn opt_len(&self) -> Option<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,12 +284,38 @@ where
         wrap_either!(self, iter => iter.flat_map(map_op))
     }
 
+    pub fn flat_map_iter<F, I>(
+        self,
+        map_op: F,
+    ) -> CondIterator<ri::FlatMapIter<P, F>, si::FlatMap<S, I, F>>
+    where
+        F: Fn(P::Item) -> I + Sync + Send,
+        I: IntoIterator,
+        I::Item: Send,
+    {
+        match self {
+            Parallel(iter) => Parallel(iter.flat_map_iter(map_op)),
+            Serial(iter) => Serial(iter.flat_map(map_op)),
+        }
+    }
+
     pub fn flatten(self) -> CondIterator<ri::Flatten<P>, si::Flatten<S>>
     where
         P::Item: IntoParallelIterator,
         S::Item: IntoIterator<Item = <P::Item as IntoParallelIterator>::Item>,
     {
         wrap_either!(self, iter => iter.flatten())
+    }
+
+    pub fn flatten_iter(self) -> CondIterator<ri::FlattenIter<P>, si::Flatten<S>>
+    where
+        P::Item: IntoIterator,
+        <P::Item as IntoIterator>::Item: Send,
+    {
+        match self {
+            Parallel(iter) => Parallel(iter.flatten_iter()),
+            Serial(iter) => Serial(iter.flatten()),
+        }
     }
 
     pub fn reduce<OP, ID>(self, identity: ID, op: OP) -> P::Item

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,6 +772,10 @@ where
     {
         wrap_either!(self, iter => iter.positions(predicate))
     }
+
+    pub fn step_by(self, step: usize) -> CondIterator<ri::StepBy<P>, si::StepBy<S>> {
+        wrap_either!(self, iter => iter.step_by(step))
+    }
 }
 
 impl<P, S> CondIterator<P, S>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 //! Then in your code, it may be used something like this:
 //!
 //! ```rust
-//! extern crate rayon_cond;
-//!
 //! use rayon_cond::CondIterator;
 //!
 //! fn main() {
@@ -29,10 +27,6 @@
 //! }
 //! ```
 
-extern crate either;
-extern crate itertools;
-extern crate rayon;
-
 use either::Either;
 use itertools::Itertools;
 use rayon::prelude::*;
@@ -42,7 +36,7 @@ use itertools::structs as it;
 use rayon::iter as ri;
 use std::iter as si;
 
-use CondIterator::*;
+use crate::CondIterator::*;
 
 /// An iterator that could be parallel or serial, with a common API either way.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,15 @@ where
         wrap_either!(self, iter => iter.cloned())
     }
 
+    pub fn copied<'a, T>(self) -> CondIterator<ri::Copied<P>, si::Copied<S>>
+    where
+        T: 'a + Copy + Sync + Send,
+        P: ParallelIterator<Item = &'a T>,
+        S: Iterator<Item = &'a T>,
+    {
+        wrap_either!(self, iter => iter.copied())
+    }
+
     pub fn inspect<OP>(self, inspect_op: OP) -> CondIterator<ri::Inspect<P, OP>, si::Inspect<S, OP>>
     where
         OP: Fn(&P::Item) + Sync + Send,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,6 +762,16 @@ where
             Serial(mut iter) => iter.position(predicate),
         }
     }
+
+    pub fn positions<Pred>(
+        self,
+        predicate: Pred,
+    ) -> CondIterator<ri::Positions<P, Pred>, it::Positions<S, Pred>>
+    where
+        Pred: Fn(P::Item) -> bool + Sync + Send,
+    {
+        wrap_either!(self, iter => iter.positions(predicate))
+    }
 }
 
 impl<P, S> CondIterator<P, S>


### PR DESCRIPTION
This now requires Rust 1.38 and adds the following methods:

```rust
    pub fn copied<'a, T>(self) -> CondIterator<ri::Copied<P>, si::Copied<S>>;

    pub fn flat_map_iter<F, I>(
        self,
        map_op: F,
    ) -> CondIterator<ri::FlatMapIter<P, F>, si::FlatMap<S, I, F>>;

    pub fn flatten_iter(self) -> CondIterator<ri::FlattenIter<P>, si::Flatten<S>>;

    pub fn positions<Pred>(
        self,
        predicate: Pred,
    ) -> CondIterator<ri::Positions<P, Pred>, it::Positions<S, Pred>>;

    pub fn step_by(self, step: usize) -> CondIterator<ri::StepBy<P>, si::StepBy<S>>;
```