### PR TITLE
Upgrade to itertools 11, and release 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2018"
 
 [dependencies]
 rayon = "1.5"
-itertools = "0.10"
+itertools = "0.11"
 either = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon-cond"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 description = "Experimental iterator wrapper that is conditionally parallel or serial."
 repository = "https://github.com/cuviper/rayon-cond"
@@ -9,9 +9,10 @@ readme = "README.md"
 keywords = ["parallel", "iterator"]
 categories = ["concurrency"]
 exclude = ["/.cirrus.yml"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.59.0"
 
 [dependencies]
-rayon = "1.5"
+rayon = "1.7"
 itertools = "0.11"
 either = "1.6"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First add this crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rayon-cond = "0.2"
+rayon-cond = "0.3"
 ```
 
 Then in your code, it may be used something like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,6 +785,7 @@ where
     P: IndexedParallelIterator,
     S: ExactSizeIterator<Item = P::Item>,
 {
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         either!(self, ref iter => iter.len())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ where
     {
         match self {
             Parallel(iter) => iter.reduce_with(op),
-            Serial(iter) => iter.fold1(op),
+            Serial(iter) => iter.reduce(op),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,16 +15,14 @@
 //! ```rust
 //! use rayon_cond::CondIterator;
 //!
-//! fn main() {
-//!     let args: Vec<_> = std::env::args().collect();
+//! let args: Vec<_> = std::env::args().collect();
 //!
-//!     // Run in parallel if there are an even number of args
-//!     let par = args.len() % 2 == 0;
+//! // Run in parallel if there are an even number of args
+//! let par = args.len() % 2 == 0;
 //!
-//!     CondIterator::new(args, par).enumerate().for_each(|(i, arg)| {
-//!         println!("arg {}: {:?}", i, arg);
-//!     });
-//! }
+//! CondIterator::new(args, par).enumerate().for_each(|(i, arg)| {
+//!     println!("arg {}: {:?}", i, arg);
+//! });
 //! ```
 
 use either::Either;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rayon-cond = "0.2"
+//! rayon-cond = "0.3"
 //! ```
 //!
 //! Then in your code, it may be used something like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,17 +88,11 @@ where
     }
 
     pub fn is_parallel(&self) -> bool {
-        match self {
-            Parallel(_) => true,
-            _ => false,
-        }
+        matches!(self, Parallel(_))
     }
 
     pub fn is_serial(&self) -> bool {
-        match self {
-            Serial(_) => true,
-            _ => false,
-        }
+        matches!(self, Serial(_))
     }
 }
 


### PR DESCRIPTION
- Upgrade to itertools v11
- Bump to version 0.3.0
- Fix clippy::needless_doctest_main
- Fix clippy::match_like_matches_macro
- Allow clippy::len_without_is_empty
